### PR TITLE
fixed error mapping on wind_degree & wind_dir

### DIFF
--- a/src/Response/Forecast/Hour.php
+++ b/src/Response/Forecast/Hour.php
@@ -80,8 +80,8 @@ class Hour
     /**
      * @var int|null
      *
-     * @Serializer\Property("int")
-     * @Serializer\Type("float")
+     * @Serializer\Property("wind_degree")
+     * @Serializer\Type("int")
      * @Serializer\IgnoreNull()
      */
     private $windDegree;
@@ -89,8 +89,8 @@ class Hour
     /**
      * @var string|null
      *
-     * @Serializer\Property("string")
-     * @Serializer\Type("float")
+     * @Serializer\Property("wind_dir")
+     * @Serializer\Type("string")
      * @Serializer\IgnoreNull()
      */
     private $windDirection;


### PR DESCRIPTION
Hello,

There are some mapping errors for the node Hour in Forecast.
The direction and temperature of the wind was wrong.
